### PR TITLE
fix(Parser): changed separation character for nested properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,9 @@ Both property names and values are case insensitve
 
 #### Nested/Owned properties
 
-`job.title=eq:Miner`
+For nested properties use `|` to separate path to property
+
+`job|title=eq:Miner`
 
 #### Pagination
 

--- a/src/QueryQuiver/QueryParser.cs
+++ b/src/QueryQuiver/QueryParser.cs
@@ -52,11 +52,13 @@ public static class QueryParser
         return filterConditions;
     }
 
-    private static FilterCondition ParseFilter(string column, string unparsedFilter)
+    private static FilterCondition ParseFilter(string unparsedColumn, string unparsedFilter)
     {
+        var column = unparsedColumn.Replace("|", ".");
+
         var parts = unparsedFilter.Split(':');
         if (parts.Length != 2)
-            throw new ArgumentException($"Invalid filter format: {column}");
+            throw new ArgumentException($"Invalid filter format: {unparsedColumn}");
 
         var unparsedOperator = parts[0];
         var value = parts[1];

--- a/tests/QueryQuiver.Tests/QueryParserTests.cs
+++ b/tests/QueryQuiver.Tests/QueryParserTests.cs
@@ -92,4 +92,21 @@ public class QueryParserTests
         QueryData expectedQueryData = new(0, 20, null, [new("column", "value with spaces", FilterOperator.Equal)]);
         Assert.Equal(expectedQueryData, queryData);
     }
+
+    [Fact]
+    public void Parse_NestedProperties_ReturnsCorrectData()
+    {
+        //Arrange
+        Dictionary<string, string[]> rawFilters = new()
+        {
+            {"nested|property", ["eq:value"]}
+        };
+
+        //Act
+        var queryData = QueryParser.Parse(rawFilters);
+
+        //Assert
+        QueryData expectedQueryData = new(0, 20, null, [new("nested.property", "value", FilterOperator.Equal)]);
+        Assert.Equal(expectedQueryData, queryData);
+    }
 }


### PR DESCRIPTION
changed separation character for nested properties from '.' to '|' (because of way bug with api query params)